### PR TITLE
Support Soa vector to be Sync, Send

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -37,6 +37,9 @@ pub struct Slice<T: Soars, D: ?Sized = [()]> {
     pub(crate) dst: D,
 }
 
+unsafe impl<T: Soars, D: ?Sized> Sync for Slice<T, D> where T: Sync {}
+unsafe impl<T: Soars, D: ?Sized> Send for Slice<T, D> where T: Send {}
+
 impl<T> Slice<T, ()>
 where
     T: Soars,


### PR DESCRIPTION
Useful when Soa is accessed from multiple threads.

Maybe this could be implemented in more safe way.