### PR TITLE
Added #[inline] attributes for element access functions

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -36,6 +36,7 @@ where
     where
         T: 'a;
 
+    #[inline]
     fn get(self, slice: &Slice<T>) -> Option<Self::Output<'_>> {
         if self < slice.len() {
             Some(unsafe { slice.raw().offset(self).get_ref() })
@@ -44,6 +45,7 @@ where
         }
     }
 
+    #[inline]
     fn get_mut(self, slice: &mut Slice<T>) -> Option<Self::OutputMut<'_>> {
         if self < slice.len() {
             Some(unsafe { slice.raw().offset(self).get_mut() })
@@ -65,6 +67,7 @@ where
     where
         T: 'a;
 
+    #[inline]
     fn get(self, slice: &Slice<T>) -> Option<Self::Output<'_>> {
         Some(SliceRef {
             slice: unsafe { slice.as_sized() },
@@ -73,6 +76,7 @@ where
         })
     }
 
+    #[inline]
     fn get_mut(self, slice: &mut Slice<T>) -> Option<Self::OutputMut<'_>> {
         Some(SliceMut {
             slice: unsafe { slice.as_sized() },
@@ -94,6 +98,7 @@ where
     where
         T: 'a;
 
+    #[inline]
     fn get(self, slice: &Slice<T>) -> Option<Self::Output<'_>> {
         let len = self.len();
         (len + self.start <= slice.len()).then(|| SliceRef {
@@ -103,6 +108,7 @@ where
         })
     }
 
+    #[inline]
     fn get_mut(self, slice: &mut Slice<T>) -> Option<Self::OutputMut<'_>> {
         self.get(slice).map(|s| SliceMut {
             slice: unsafe { s.as_sized() },
@@ -124,10 +130,12 @@ where
     where
         T: 'a;
 
+    #[inline]
     fn get(self, slice: &Slice<T>) -> Option<Self::Output<'_>> {
         (0..self.end).get(slice)
     }
 
+    #[inline]
     fn get_mut(self, slice: &mut Slice<T>) -> Option<Self::OutputMut<'_>> {
         (0..self.end).get_mut(slice)
     }
@@ -145,10 +153,12 @@ where
     where
         T: 'a;
 
+    #[inline]
     fn get(self, slice: &Slice<T>) -> Option<Self::Output<'_>> {
         (0..self.end + 1).get(slice)
     }
 
+    #[inline]
     fn get_mut(self, slice: &mut Slice<T>) -> Option<Self::OutputMut<'_>> {
         (0..self.end + 1).get_mut(slice)
     }
@@ -166,10 +176,12 @@ where
     where
         T: 'a;
 
+    #[inline]
     fn get(self, slice: &Slice<T>) -> Option<Self::Output<'_>> {
         (self.start..slice.len()).get(slice)
     }
 
+    #[inline]
     fn get_mut(self, slice: &mut Slice<T>) -> Option<Self::OutputMut<'_>> {
         (self.start..slice.len()).get_mut(slice)
     }
@@ -187,10 +199,12 @@ where
     where
         T: 'a;
 
+    #[inline]
     fn get(self, slice: &Slice<T>) -> Option<Self::Output<'_>> {
         (*self.start()..*self.end() + 1).get(slice)
     }
 
+    #[inline]
     fn get_mut(self, slice: &mut Slice<T>) -> Option<Self::OutputMut<'_>> {
         (*self.start()..*self.end() + 1).get_mut(slice)
     }

--- a/src/iter_raw.rs
+++ b/src/iter_raw.rs
@@ -68,6 +68,7 @@ where
 {
     type Item = A::Item;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.len == 0 {
             None
@@ -90,6 +91,7 @@ where
         self.len
     }
 
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         if n >= self.len {
             self.len = 0;
@@ -146,6 +148,7 @@ where
     T: Soars,
     A: IterRawAdapter<T>,
 {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.len == 0 {
             None
@@ -157,6 +160,7 @@ where
         }
     }
 
+    #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         if n >= self.len {
             self.len = 0;
@@ -192,6 +196,7 @@ macro_rules! iter_with_raw {
         {
             type Item = <$t as IterRawAdapter<T>>::Item;
 
+            #[inline]
             fn next(&mut self) -> Option<Self::Item> {
                 self.iter_raw.next()
             }
@@ -231,6 +236,7 @@ macro_rules! iter_with_raw {
         where
             T: $($lifetime +)? Soars,
         {
+            #[inline]
             fn next_back(&mut self) -> Option<Self::Item> {
                 self.iter_raw.next_back()
             }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -85,6 +85,7 @@ where
     /// Used by the [`Soars`] derive macro, but generally not intended for use
     /// by end users.
     #[doc(hidden)]
+    #[inline]
     pub const fn raw(&self) -> T::Raw {
         self.raw
     }
@@ -216,6 +217,7 @@ where
     /// assert_eq!(soa.get(1..=3).unwrap(), [Foo(40), Foo(30), Foo(20)]);
     /// assert_eq!(soa.get(2..5), None);
     /// ```
+    #[inline]
     pub fn get<I>(&self, index: I) -> Option<I::Output<'_>>
     where
         I: SoaIndex<T>,


### PR DESCRIPTION
Looks like slice in rust core adds inline to almost all functions.
https://doc.rust-lang.org/src/core/slice/index.rs.html

This should make sense in this use case too as compiler could optimize out pointer calculations to fields that are not accessed.