### PR TITLE
fix transmute_ptr_to_ptr warning

### DIFF
--- a/soa-rs-derive/src/fields.rs
+++ b/soa-rs-derive/src/fields.rs
@@ -117,11 +117,13 @@ pub fn fields_struct(
 
             fn from_slice(slice: &::soa_rs::Slice<Self::Item>) -> &Self {
                 // SAFETY: Self is `repr(transparent)` of Slice
+                #[allow(clippy::transmute_ptr_to_ptr)]
                 unsafe { ::std::mem::transmute(slice) }
             }
 
             fn from_slice_mut(slice: &mut ::soa_rs::Slice<Self::Item>) -> &mut Self {
                 // SAFETY: Self is `repr(transparent)` of Slice
+                #[allow(clippy::transmute_ptr_to_ptr)]
                 unsafe { ::std::mem::transmute(slice) }
             }
         }

--- a/soa-rs-derive/src/zst.rs
+++ b/soa-rs-derive/src/zst.rs
@@ -18,10 +18,10 @@ pub fn zst_struct(ident: Ident, vis: Visibility, kind: ZstKind) -> TokenStream {
         unsafe impl ::soa_rs::Soars for #ident {
             type Raw = #raw;
             type Deref = #deref;
-            type Ref<'a> = #ident;
-            type RefMut<'a> = #ident;
-            type Slices<'a> = #ident;
-            type SlicesMut<'a> = #ident;
+            type Ref<'a> = Self;
+            type RefMut<'a> = Self;
+            type Slices<'a> = Self;
+            type SlicesMut<'a> = Self;
         }
 
         #[allow(dead_code)]
@@ -64,21 +64,23 @@ pub fn zst_struct(ident: Ident, vis: Visibility, kind: ZstKind) -> TokenStream {
 
             fn from_slice(slice: &::soa_rs::Slice<Self::Item>) -> &Self {
                 // SAFETY: Self is `repr(transparent)` of Slice
+                #[allow(clippy::transmute_ptr_to_ptr)]
                 unsafe { ::std::mem::transmute(slice) }
             }
 
             fn from_slice_mut(slice: &mut ::soa_rs::Slice<Self::Item>) -> &mut Self {
                 // SAFETY: Self is `repr(transparent)` of Slice
+                #[allow(clippy::transmute_ptr_to_ptr)]
                 unsafe { ::std::mem::transmute(slice) }
             }
         }
 
         #[automatically_derived]
         impl ::soa_rs::AsSoaRef for #ident {
-            type Item = #ident;
+            type Item = Self;
 
             fn as_soa_ref(&self) -> Self::Item {
-                #ident #unit_construct
+                Self #unit_construct
             }
         }
 

--- a/soa-rs-testing/benches/benchmark.rs
+++ b/soa-rs-testing/benches/benchmark.rs
@@ -47,7 +47,7 @@ impl Vec4 {
     }
 }
 
-impl<'a> Vec4Ref<'a> {
+impl Vec4Ref<'_> {
     fn dot(&self, other: &Self) -> f32 {
         self.0 * other.0 + self.1 * other.1 + self.2 * other.2 + self.3 * other.3
     }

--- a/soa-rs-testing/src/lib.rs
+++ b/soa-rs-testing/src/lib.rs
@@ -693,3 +693,13 @@ fn for_each_double_free() {
 
     buffer.into_iter().for_each(|_| {});
 }
+
+#[test]
+fn no_transmute_ptr_to_ptr_warning() {
+    #![deny(clippy::transmute_ptr_to_ptr)]
+
+    #[derive(Soars)]
+    struct Dummy {
+        field: i32,
+    }
+}


### PR DESCRIPTION
Clippy with pedantic preset generates `transmute_ptr_to_ptr` warning on Soars macro expansion. This mr fixes it.
```
warning: transmute from a reference to a reference
   --> src/storage/models.rs:667:24
    |
667 | #[derive(Debug, Clone, Soars)]
    |                        ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ptr
    = note: this warning originates in the derive macro `Soars` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Alternatively, transmute can be replaced with clippy suggestion
```rust
&mut *(slice as *mut soa_rs::Slice<Self::Item> as *mut Self)
```

By the way, the test case for this is not ideal. It only works when you run `cargo clippy` on `soa-rs-testing` because this attribute belongs to `clippy`, not `rustc`, so a regular `cargo test` won't do anything.
